### PR TITLE
Admin Shelter Show Page, only return name and full address

### DIFF
--- a/app/controllers/admin/shelters_controller.rb
+++ b/app/controllers/admin/shelters_controller.rb
@@ -5,7 +5,6 @@ class Admin::SheltersController < ApplicationController
   end
 
   def show
-    @shelter = Shelter.find(params[:id])
+    @shelter = Shelter.name_and_address(params[:id])
   end
-  
 end

--- a/app/controllers/admin/shelters_controller.rb
+++ b/app/controllers/admin/shelters_controller.rb
@@ -3,4 +3,9 @@ class Admin::SheltersController < ApplicationController
     @shelters = Shelter.rev_alphabetize
     @pending = Shelter.shelters_with_pending_apps
   end
+
+  def show
+    @shelter = Shelter.find(params[:id])
+  end
+  
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -17,13 +17,17 @@ class Shelter < ApplicationRecord
   end
 
   def self.rev_alphabetize
-    Shelter.find_by_sql("SELECT * FROM shelters ORDER BY name DESC;")
+    find_by_sql("SELECT * FROM shelters ORDER BY name DESC;")
   end
 
   def self.shelters_with_pending_apps
-    Shelter.joins( pets: :applications).where("applications.status = 'Pending'")  
+    joins( pets: :applications).where("applications.status = 'Pending'")
   end
 
+  def self.name_and_address(shelter_id)
+    find_by_sql("SELECT name, street_address, city, state, zip_code FROM shelters WHERE shelters.id = #{shelter_id}")
+  end
+  
   def pet_count
     pets.count
   end

--- a/app/views/admin/shelters/show.html.erb
+++ b/app/views/admin/shelters/show.html.erb
@@ -1,0 +1,5 @@
+<h4> <i>** Admin View **</i> </h4>
+<h2> <%= @shelter.first.name %> </h2>
+<p><b>Address:</b> <br>
+  <%= @shelter.first.street_address %> <br>
+  <%= @shelter.first.city %>, <%= @shelter.first.state  %> <%= @shelter.first.zip_code %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,5 +45,6 @@ Rails.application.routes.draw do
   post '/pet_applications', to: 'pet_applications#create'
 
   get '/admin/shelters', to: 'admin/shelters#index'
+  get '/admin/shelters/:id', to: 'admin/shelters#show'
 
 end

--- a/db/migrate/20220523194257_add_full_address_to_shelter.rb
+++ b/db/migrate/20220523194257_add_full_address_to_shelter.rb
@@ -1,0 +1,7 @@
+class AddFullAddressToShelter < ActiveRecord::Migration[5.2]
+  def change
+    add_column :shelters, :street_address, :string
+    add_column :shelters, :state, :string
+    add_column :shelters, :zip_code, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_19_210001) do
+ActiveRecord::Schema.define(version: 2022_05_23_194257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,9 @@ ActiveRecord::Schema.define(version: 2022_05_19_210001) do
     t.integer "rank"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "street_address"
+    t.string "state"
+    t.integer "zip_code"
   end
 
   create_table "veterinarians", force: :cascade do |t|

--- a/spec/features/admin/shelters/show_spec.rb
+++ b/spec/features/admin/shelters/show_spec.rb
@@ -6,14 +6,19 @@
 require 'rails_helper'
 
 describe 'admin shelter show page', type: :feature do
-  let!(:shelter_1) {Shelter.create!(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)}
+  let!(:shelter_1) {Shelter.create!(name: 'Aurora shelter', street_address: '15 Fluff Lane', state: 'CO', zip_code: 80152, city: 'Aurora', foster_program: false, rank: 9)}
   let!(:shelter_2) {Shelter.create!(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)}
-  let!(:shelter_3) {Shelter.create!(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)}
+  # let!(:shelter_3) {Shelter.create!(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)}
 
   it "shows the shelter's name and full address" do
     visit "/admin/shelters/#{shelter_1.id}"
 
-    expect(page).to have_content()
+    expect(page).to have_content('Aurora shelter')
+    expect(page).to have_content('15 Fluff Lane')
+    expect(page).to have_content('CO')
+    expect(page).to have_content(80152)
+    expect(page).to have_content('Aurora')
+    expect(page).to_not have_content('RGV animal shelter')
   end
 
 end

--- a/spec/features/admin/shelters/show_spec.rb
+++ b/spec/features/admin/shelters/show_spec.rb
@@ -1,0 +1,19 @@
+# Admin Shelters Show Page
+#
+# As a visitor
+# When I visit an admin shelter show page
+# Then I see that shelter's name and full address
+require 'rails_helper'
+
+describe 'admin shelter show page', type: :feature do
+  let!(:shelter_1) {Shelter.create!(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)}
+  let!(:shelter_2) {Shelter.create!(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)}
+  let!(:shelter_3) {Shelter.create!(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)}
+
+  it "shows the shelter's name and full address" do
+    visit "/admin/shelters/#{shelter_1.id}"
+
+    expect(page).to have_content()
+  end
+
+end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Shelter, type: :model do
   end
 
   before(:each) do
-    @shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
-    @shelter_2 = Shelter.create(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)
-    @shelter_3 = Shelter.create(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)
+    @shelter_1 = Shelter.create!(name: 'Aurora shelter', street_address: '15 Fluff Lane', state: 'CO', zip_code: 80152, city: 'Aurora', foster_program: false, rank: 9)
+    @shelter_2 = Shelter.create!(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)
+    @shelter_3 = Shelter.create!(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)
 
     @pet_1 = @shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: false)
     @pet_2 = @shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
@@ -27,6 +27,18 @@ RSpec.describe Shelter, type: :model do
     describe '#search' do
       it 'returns partial matches' do
         expect(Shelter.search("Fancy")).to eq([@shelter_3])
+      end
+    end
+
+    describe '#name_and_address' do
+      it 'returns only the name and address of a shelter' do
+        matching_shelter = Shelter.name_and_address(@shelter_1.id).first
+
+        expect(matching_shelter.name).to eq('Aurora shelter')
+        expect(matching_shelter.street_address).to eq('15 Fluff Lane')
+        expect(matching_shelter.state).to eq('CO')
+        expect(matching_shelter.zip_code).to eq(80152)
+        expect(matching_shelter.city).to eq('Aurora')
       end
     end
 


### PR DESCRIPTION
Just ran through this with you via zoom but created an SQL only query to retrieve just the names and addresses for shelters on the admin shelter show page. This required a few things:
- A migration to add the columns to accommodate a full address
- Creation of an admin/shelter/:id show page
- A model test to retrieve the specified data, which I then used in the shelter#show action.
All tests are passing and simplecov is at 100%