### PR TITLE
Approved application changes pet status to not adoptable

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -3,10 +3,9 @@ class Admin::ApplicationsController < ApplicationController
   def show
     @application = Application.find(params[:id])
     if @application.approved?
-      @application.update(status: "Approved")
+      @application.approve_application
     elsif @application.rejected?
-      @application.update(status: "Rejected")
+      @application.reject_application
     end
   end
 end
-

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -22,4 +22,15 @@ class Application < ApplicationRecord
 		pet_applications.any?{ |pet_app| pet_app.application_status  == "Rejected"  }
 
 	end
+
+	def approve_application
+		update(status: "Approved")
+		pets.each { |pet| pet.update(adoptable: false)}
+		# require "pry"; binding.pry #when I pry in here
+		# #the pet value is false
+	end
+
+	def reject_application
+		update(status: "Rejected")
+	end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -63,5 +63,31 @@ RSpec.describe Application, type: :model do
 				expect(app_1.status).to eq("In Progress")
 			end
 		end
+
+		describe ".approve_application" do
+			it "changes an application status to approved and makes the pets associated to no longer adoptable" do
+				expect(app_1.status). to eq("In Progress")
+
+				Pet.find(app_1.pet_ids).each do |pet|
+					expect(pet.adoptable).to eq(true)
+				end
+				
+				app_1.approve_application
+				expect(app_1.status). to eq("Approved")
+
+				Pet.find(app_1.pet_ids).each do |pet|
+					expect(pet.adoptable).to eq(false)
+				end
+			end
+		end
+
+
+		describe ".reject_application" do
+			it "changes an application status to rejected" do
+				expect(app_1.status). to eq("In Progress")
+				app_1.reject_application
+				expect(app_1.status). to eq("Rejected")
+			end
+		end
 	end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -24,34 +24,44 @@ RSpec.describe Application, type: :model do
 	end
 
 	describe "instance methods" do
-		it "returns true if the application has 1 or more pets" do
-			expect(app_1.has_pets?).to eq(true)
-			expect(app_2.has_pets?).to eq(false)
+
+		describe ".has_pets?" do
+			it "returns true if the application has 1 or more pets" do
+				expect(app_1.has_pets?).to eq(true)
+				expect(app_2.has_pets?).to eq(false)
+			end
+		end
+
+		describe ".approved?" do
+			it " returns true if all applications are approved" do
+				pet_application_2.update(application_status: "Approved")
+				pet_application_1.update(application_status: "Approved")
+				expect(app_1.approved?).to eq(true)
+			end
+
+			it " returns false if all applications are not approved" do
+				pet_application_1.update(application_status: "Approved")
+				expect(app_1.approved?).to eq(false)
+			end
+		end
+
+		describe ".rejected?" do
+			it " returns true if any applications are rejected" do
+				pet_application_2.update(application_status: "Approved")
+				pet_application_1.update(application_status: "Rejected")
+				expect(app_1.rejected?).to eq(true)
+			end
+
+			it " returns false if all applications are not rejected" do
+				pet_application_1.update(application_status: "Approved")
+				expect(app_1.rejected?).to eq(false)
+			end
+		end
+
+		describe ".default_values" do
+			it "sets the default value to in progress" do
+				expect(app_1.status).to eq("In Progress")
+			end
 		end
 	end
-		it " returns true if all applications are approved" do
-			pet_application_2.update(application_status: "Approved")
-			pet_application_1.update(application_status: "Approved")
-			expect(app_1.approved?).to eq(true)
-		end
-
-		it " returns false if all applications are not approved" do
-			pet_application_1.update(application_status: "Approved")
-			expect(app_1.approved?).to eq(false)
-		end
-
-		it " returns true if any applications are rejected" do
-			pet_application_2.update(application_status: "Approved")
-			pet_application_1.update(application_status: "Rejected")
-			expect(app_1.rejected?).to eq(true)
-		end
-
-		it " returns false if all applications are not rejected" do
-			pet_application_1.update(application_status: "Approved")
-			expect(app_1.rejected?).to eq(false)
-		end
-
-		it "sets the default value to in progress" do
-			expect(app_1.status).to eq("In Progress")
-		end
 end


### PR DESCRIPTION
Changed the controller to have an accept_application and a reject_application rather than directly updating the status in the controller. Did this so that I could add changing the pet adoptable status to false for each pet when approving, then for consistency I thought there should be a method in the model for rejecting an application. 

All tests passing, simple cov models and features are at 100% and local host runs no problem.